### PR TITLE
Add disclaimer to site footer

### DIFF
--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,3 +1,6 @@
 <!-- start custom footer snippets -->
 <a href="/sitemap/">Sitemap</a>
+<p class="page__footer-copyright" style="font-size: 0.75em; margin-top: 0.5em;">
+  Any opinions I state on this site or on linked media or content are my own and are neither affiliated with nor endorsed by any employer, institution, person, or organization. Presentation of statements made by others (such as in page comments or in audio or video segments), references and/or links to such statements or content of others do not constitute my endorsement; these statements are solely affiliated with their respective authors. Content is provided for reference without any warranty as to its correctness or suitability for a given purpose.
+</p>
 <!-- end custom footer snippets -->


### PR DESCRIPTION
## Summary

- Adds an opinions/endorsement/warranty disclaimer paragraph to `_includes/footer/custom.html`
- Disclaimer appears on every page of the site via the shared footer
- Styled with the existing `page__footer-copyright` class at 0.75em to read as fine print

## Test plan

- [ ] Build the site locally and verify the disclaimer appears in the footer on multiple page types (home, post, talk, etc.)
- [ ] Confirm styling is legible and consistent with the existing footer text

https://claude.ai/code/session_01K8xfhG49EXyMANJ9tby5bY

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8xfhG49EXyMANJ9tby5bY)_