### PR TITLE
Add AutoGUI blog post and software portfolio entry

### DIFF
--- a/_posts/2026-05-15-autogui.md
+++ b/_posts/2026-05-15-autogui.md
@@ -1,0 +1,207 @@
+---
+title: 'AutoGUI: A Vendor-Neutral Desktop Automation Agent for LLMs'
+date: 2026-05-15
+permalink: /posts/2026/05/autogui/
+tags:
+ - ai
+ - agents
+ - desktop
+ - automation
+ - python
+ - typescript
+---
+
+Most LLM agents can read files, call APIs, and run shell commands, but they have
+no reliable way to operate a graphical desktop. They cannot click a button in a
+running application, verify that a dialog appeared, fill a form field, or observe
+what is currently on screen. [AutoGUI](https://github.com/BillJr99/AutoGUI) is a
+research prototype that fills that gap. It connects any OpenAI-compatible LLM —
+including models served locally through [OpenWebUI](https://openwebui.com/) or
+directly through [Ollama](https://ollama.com/) — to a full suite of OS-level desktop
+controls via a ReAct-style agentic loop.
+
+> **Experimental software — use at your own risk.**
+> AutoGUI is a research prototype. It is not intended for, and has not been
+> evaluated or deemed suitable for, any particular purpose, production
+> use, or critical workload. No warranty is provided, express or implied.
+> The agent operates at OS level and can run shell commands, click anything,
+> type anywhere, read and write files, and take screenshots.
+> **Run it only in a sandbox, VM, or container that you are willing to reset.**
+> Restrict the REST API to loopback (`AUTOGUI_API_HOST=127.0.0.1`) and consider
+> disabling shell access (`"allowed_shell": false`) if you do not fully trust
+> the task or the model driving it.
+
+## Two Delivery Modes
+
+AutoGUI ships in two forms. The standalone Python CLI/TUI agent connects any
+OpenWebUI instance (or any OpenAI-compatible endpoint) to your desktop. The
+native TypeScript Pi extension brings the same tools into the
+[Pi](https://pi.dev) terminal harness behind a single `/autogui` command, with
+no dependency on the Python agent or OpenWebUI.
+
+Both share the same tool surface — shell execution, filesystem access, pixel
+and accessibility-tree clicking, Playwright browser automation — but they differ
+in how the LLM loop is owned. The standalone agent runs its own ReAct loop;
+the Pi extension delegates loop ownership to Pi.
+
+## Architecture
+
+The standalone Python agent is organized around five main components.
+
+```
+main.py             Entry point — validation, component wiring, TUI/CLI dispatch
+│
+├── agent.py        ReAct loop + typed-plan controller
+│   └─ controller   Preflight, predicate checks, replan-on-block, budget ceilings
+│
+├── tools.py        Tool registry
+│   ├─ shell_run / fs_read / fs_write / fs_list
+│   ├─ desktop_screenshot / click / type / hotkey / scroll / launch
+│   ├─ desktop_click_element   (a11y-first: UIAutomation / AT-SPI)
+│   ├─ desktop_click_mark      (Set-of-Mark grounding)
+│   ├─ browser_navigate / click / fill / eval   (Playwright)
+│   ├─ skill_save / skill_list / skill_run
+│   └─ memory_get / memory_note
+│
+├── backends/       Platform-specific automation backends
+│   ├─ windows.py   UIAutomation + SendInput (user32)
+│   ├─ macos.py     screencapture + osascript
+│   ├─ linux_x11.py xdotool + wmctrl
+│   └─ linux_wayland.py  grim + ydotool + swaymsg
+│
+├── api.py          FastAPI REST server (auto-started in background)
+│   ├─ POST /api/task          Submit task
+│   ├─ GET  /api/task/{id}/stream  SSE live event stream
+│   └─ GET  /api/healthz
+│
+└── tui.py          Textual TUI (status bar, model picker, tool visibility toggle)
+```
+
+The agentic loop in `agent.py` follows a standard ReAct pattern — append the
+user message to history, POST the history and tool schemas to the LLM, receive
+either a tool call or a stop response, execute the tool, append the result, and
+repeat. On top of that loop sits the controller, which adds:
+
+- **Planner** — one extra LLM call up front that produces a numbered, high-level
+  plan injected as a `[PLAN]` block into the executor's context
+- **Plan critique** — a second LLM call that reviews the plan and returns a
+  revised version when issues are found
+- **Preflight** — before the first state-changing action, verifies that apps are
+  on PATH, files exist, URLs are TCP-reachable, and named tools are registered
+- **Predicate checks** — when a plan step declares a typed post-condition
+  (`window_title_contains`, `file_exists`, `text_visible`, etc.), the controller
+  verifies it deterministically after each step completes
+- **Replan-on-block** — when a step is classified as BLOCKED, the controller
+  re-invokes the planner with the failure reason as context
+- **Visual diff** — perceptual hash of pre/post screenshots flags silent no-ops
+  where a state-changing action left the screen unchanged
+- **Watchdog** — detects when the loop is stuck by hashing the per-iteration
+  signature and routing repeated matches through the BLOCKED path
+
+## Platform Support
+
+The correct backend is detected automatically at startup via `platform_detect.detect()`.
+No configuration is required.
+
+| Platform | Screenshot | Click/Type | Accessibility Tree |
+|----------|-----------|------------|-------------------|
+| **Windows** | pyautogui | SendInput (user32) | UIAutomation |
+| **WSL** | pyautogui | pyautogui | PowerShell UIAutomation |
+| **macOS** | screencapture | pyautogui | osascript |
+| **Linux X11** | pyautogui | xdotool | AT-SPI |
+| **Linux Wayland** | grim | ydotool | AT-SPI |
+
+On Windows, click and type operations go through `user32.SendInput` directly
+via ctypes, producing real INPUT events indistinguishable from a physical
+keyboard and mouse, with correct per-monitor DPI handling and full Unicode
+support. On Linux, the `desktop_click_element` tool talks to the accessibility
+tree via AT-SPI, letting the agent click real UI controls by name and role
+rather than guessing pixel positions.
+
+## A11y-First Clicking and Set-of-Mark Grounding
+
+AutoGUI implements two layers above raw pixel clicking.
+
+`desktop_click_element(name, control_type)` resolves the target UI control
+through the OS accessibility API and clicks it by logical identity rather than
+screen position. This survives window moves, DPI scaling, and async UI redraws
+that would break a coordinate-based click.
+
+For cases where the accessibility tree is sparse or unavailable, Set-of-Mark
+grounding overlays numbered boxes on detected UI elements in a screenshot. The
+model selects an element by ID via `desktop_click_mark(mark_id)` rather than
+guessing coordinates. The fallback ladder is: `desktop_click_element` →
+`desktop_click_text` (OCR anchor) → `desktop_click_mark` → `desktop_click(x, y)`.
+
+## Skill Library and App Memory
+
+Two optional persistence layers accumulate knowledge across tasks.
+
+The skill library records successful tool sequences with `skill_save` and
+retruns them by keyword with `skill_list` and `skill_run`. At the start of each
+task the planner receives the top-3 matching skills as few-shot exemplars, so
+recurring workflows get faster and more reliable over time. Skill creation is
+gated by `agent.skills_enabled` (default false); reads always work.
+
+The app-memory store records per-app quirks, failure counts, and free-form notes
+via `memory_note`. At the start of each task the planner receives app memory
+hints for any visible applications, biasing plans toward strategies that worked
+before. Memory creation is gated by `agent.memory.enabled` (default false);
+reads always work.
+
+## REST API and TUI
+
+The FastAPI REST server starts automatically in the background whenever you run
+`main.py`. It exposes task submission, SSE live event streaming, and a liveness
+probe, making AutoGUI accessible to web UIs, scripts, and CI pipelines without
+the terminal UI.
+
+The Textual TUI provides a scrollable conversation pane with a status bar
+showing the current model name, conversation length, and tool visibility state.
+The live model picker (Ctrl+P → "Change Model") fetches the current model list
+from the server; selecting a model takes effect immediately and can optionally
+be persisted to `config.json`.
+
+## Experimental Nature and Safety Considerations
+
+AutoGUI is a research prototype, not a production tool. A few properties of the
+current design are worth understanding before running it.
+
+The destructive command guard in `shell_run` blocks patterns like `rm -rf`,
+`DROP TABLE`, and `dd if=`, but it is a regex filter, not a sandbox. For
+untrusted tasks, set `"allowed_shell": false` or run the agent inside a
+container with a disposable filesystem.
+
+The REST API has no authentication and binds to `0.0.0.0` by default. Set
+`AUTOGUI_API_HOST=127.0.0.1` for loopback-only access or
+`AUTOGUI_DISABLE_API=1` to disable the background API entirely.
+
+The agent operates at OS level. It can click anything, type anywhere, read and
+write files, and take screenshots. The safety countdown (`safety.command_confirm_delay_seconds`,
+default 5 seconds) gives a visible window before each tool dispatch, with
+Escape-to-cancel, but it is not a substitute for running in an environment you
+are prepared to reset.
+
+For the same reason, AutoGUI should not be pointed at tasks that involve
+sensitive data or credentials unless the environment is appropriately isolated.
+Screen content captured during observation passes through the model's context
+window; if you are using a cloud-hosted model, treat everything visible on
+screen as potentially logged.
+
+## Getting Started
+
+Clone the repository from [https://github.com/BillJr99/AutoGUI](https://github.com/BillJr99/AutoGUI),
+install the Python dependencies, copy `config.json.example` to `config.json`,
+and set your OpenWebUI URL, API key, and model. Run `python main.py --check`
+to verify connectivity before launching the TUI or issuing single-command
+tasks.
+
+The optional install script at `scripts/install-dependencies.sh` (or `.cmd`/`.ps1`
+on Windows) adds Tesseract for OCR-anchored clicking, Playwright for browser
+automation, AT-SPI on Linux for accessibility-tree element clicking, and
+ImageMagick for Set-of-Mark overlays and failure GIF recording.
+
+A pytest suite under `tests/` exercises the controller, predicates, budget
+ceilings, preflight, and visual diff modules with no live model and no desktop
+required — useful for validating changes to the orchestration logic without
+burning real API calls.

--- a/_software/autogui.md
+++ b/_software/autogui.md
@@ -1,0 +1,64 @@
+---
+title: "AutoGUI Desktop Agent"
+excerpt: "A vendor-neutral desktop automation agent that connects any OpenWebUI-compatible LLM to OS-level controls — shell, filesystem, screenshots, accessibility-tree clicks, browser automation, and more — via a ReAct-style agentic loop."
+collection: software
+comments: true
+tags:
+  - ai
+  - agentic
+  - desktop
+  - automation
+  - python
+  - typescript
+---
+
+AutoGUI is a desktop automation agent available in two forms: a standalone Python CLI/TUI agent that connects any [OpenWebUI](https://openwebui.com/) instance (or any OpenAI-compatible endpoint, including local Ollama) to your desktop, and a native TypeScript [Pi](https://pi.dev) Coding Agent extension that lets Pi own the agent workflow while AutoGUI supplies the desktop tools.
+
+The standalone agent drives a ReAct-style loop (Reason → Act → Observe → repeat) and can run shell commands, read and write files, take screenshots, click and type via pixel coordinates or OS accessibility trees, launch programs, and inspect application UI element hierarchies — all via function-calling with any model in your OpenWebUI instance. A Playwright-backed browser tool family, Set-of-Mark visual grounding, a skill library for saving and replaying successful tool sequences, and a per-app memory store for recording quirks and failure patterns round out the feature set.
+
+The architecture follows [UFO](https://github.com/microsoft/UFO) and [open-interpreter](https://github.com/OpenInterpreter/open-interpreter) but is provider-neutral: any model that supports OpenAI-compatible tool calling works out of the box. A FastAPI REST server wraps the agent class for programmatic task submission and live SSE event streaming.
+
+> **⚠ Experimental Software — Use in a Sandbox**
+> AutoGUI is a research prototype. It is not intended for, nor evaluated or deemed suitable for, any particular production use or critical workload. No warranty is provided, express or implied. The agent operates at OS level and can run shell commands, click anything, type anywhere, read and write files, and take screenshots. **Run it only in a sandbox, VM, or container you are willing to reset.** Restrict the API to loopback and disable shell access if you do not fully trust the task or model driving it.
+
+This software is distributed under the [MIT License](https://opensource.org/licenses/MIT).
+
+The package is hosted on GitHub at:
+
+[AutoGUI Desktop Agent](https://github.com/BillJr99/AutoGUI)
+
+## Architecture
+
+The standalone Python agent is organized around five main components:
+
+- **`agent.py`** — the agentic ReAct loop, with a typed-plan controller layered on top for preflight checks, per-step predicate verification, and replan-on-block
+- **`tools.py`** — the tool registry: shell, filesystem, all desktop backends, Playwright browser, skill library, and app-memory tools
+- **`backends/`** — platform-specific desktop automation backends for Windows (UIAutomation + SendInput), macOS (screencapture, osascript), Linux X11 (xdotool, wmctrl), and Linux Wayland (grim, ydotool, swaymsg)
+- **`api.py`** — a FastAPI REST server that wraps the agent for programmatic access, running automatically in the background alongside the TUI or CLI
+- **`tui.py`** — a Textual interactive terminal UI with a live status bar, tool visibility toggle, and live model picker
+
+The Pi extension in `pi-extension/` is implemented entirely in TypeScript and brings the same desktop tools into the Pi terminal harness behind a single `/autogui` command, with no dependency on the Python agent or OpenWebUI.
+
+## Supported Platforms
+
+| Platform | Screenshot | Click/Type | Accessibility Tree |
+|----------|-----------|------------|-------------------|
+| **Windows** | pyautogui | SendInput (user32) | UIAutomation |
+| **WSL** | pyautogui | pyautogui | PowerShell UIAutomation |
+| **macOS** | screencapture | pyautogui | osascript |
+| **Linux X11** | pyautogui | xdotool | AT-SPI |
+| **Linux Wayland** | grim | ydotool | AT-SPI |
+
+The correct backend is detected automatically at startup. No configuration is needed.
+
+## Key Features
+
+- **ReAct agentic loop** with a typed-plan controller, preflight resource checks, per-step predicate verification, and replan-on-block
+- **A11y-first clicking** via OS accessibility APIs (UIAutomation on Windows, AT-SPI on Linux) — no pixel guessing
+- **Set-of-Mark grounding** — numbered overlay on detected UI elements; model clicks by ID
+- **Playwright browser tools** — real DOM/ARIA selectors for web automation
+- **Skill library** — save, list, and replay successful tool sequences
+- **App memory** — per-app quirk database surfaced into the planner as hints
+- **Best-of-N sampling** — sample N candidate actions on uncertain steps and pick the best
+- **Failure GIF recording** — rolling 5-second screen buffer flushed to animated GIF on tool failure
+- **Safety countdown** — configurable N-second delay before each tool call with Escape-to-cancel


### PR DESCRIPTION
## Summary

This PR adds documentation for AutoGUI, a vendor-neutral desktop automation agent for LLMs, in two locations: a detailed technical blog post and a software portfolio entry.

## Changes

- **Blog post** (`_posts/2026-05-15-autogui.md`): Comprehensive technical writeup covering:
  - Overview of AutoGUI's capabilities and two delivery modes (standalone Python agent and Pi TypeScript extension)
  - Detailed architecture breakdown of the five main components (main.py, agent.py, tools.py, backends/, api.py, tui.py)
  - ReAct loop implementation with controller features (planner, plan critique, preflight checks, predicate verification, replan-on-block, visual diff, watchdog)
  - Platform support matrix for Windows, WSL, macOS, Linux X11, and Linux Wayland
  - A11y-first clicking strategy and Set-of-Mark visual grounding approach
  - Skill library and app memory persistence layers
  - REST API and TUI interface details
  - Safety considerations and experimental nature warnings
  - Getting started instructions

- **Software portfolio entry** (`_software/autogui.md`): Concise project summary including:
  - High-level description of the two delivery modes
  - Key architectural components
  - Supported platforms table
  - Feature highlights (ReAct loop, A11y clicking, Set-of-Mark grounding, Playwright browser tools, skill library, app memory, best-of-N sampling, failure GIF recording, safety countdown)
  - MIT License reference and GitHub repository link
  - Safety warning callout

Both documents emphasize the experimental nature of the software and provide clear safety guidance for sandbox/VM usage.

https://claude.ai/code/session_01PrbFS5uYfmFpLbh2hCm5zY