### PR TITLE
Add mcpproxy blog post and software documentation

### DIFF
--- a/_posts/2026-05-25-mcpproxy.md
+++ b/_posts/2026-05-25-mcpproxy.md
@@ -1,0 +1,199 @@
+---
+title: 'mcpproxy: A Config-Driven MCP Host with a Built-In Web UI'
+date: 2026-05-25
+permalink: /posts/2026/05/mcpproxy/
+tags:
+ - ai
+ - mcp
+ - agentic
+ - python
+ - docker
+---
+
+The [Model Context Protocol](https://modelcontextprotocol.io/) defines a standard
+way for AI clients to discover and call tools, but standing up a personal MCP
+server still usually means writing Python glue code, wiring up a framework, and
+restarting a process every time you add a tool.  [mcpproxy](https://github.com/BillJr99/mcpproxy)
+takes a different approach: every tool provider is a single YAML file, the server
+reloads tools at startup without any code changes to the host, and a browser-based
+web UI handles the full provider lifecycle — editing, secret management, and
+live command streaming — without leaving the browser.
+
+> **Experimental software — use with caution and in isolation.**
+> `mcpproxy` is a research prototype provided as-is, with no guarantees of
+> security, stability, or fitness for any particular purpose.  It has not
+> undergone a security audit.  The web UI has no authentication.  Do not
+> expose it to untrusted networks or use it to process sensitive data in
+> production.  Run it on a trusted network, preferably in a container or VM
+> you are prepared to reset.  See the LICENSE for full MIT terms.
+
+## How It Works
+
+`mcpproxy` exposes two ports: the MCP endpoint on **8888** (`http://localhost:8888/mcp`)
+and a web UI on **8889** (`http://localhost:8889`).  The core server (`server.py`)
+scans a `tools/` directory at startup.  Each YAML file there is a *provider*.
+A provider either embeds Python `async def` handler functions directly in a
+`code:` block, or delegates to an existing MCP npm package via an `npx:` block.
+`server.py` executes each code block (or spawns the npx process), registers
+every declared tool automatically, and serves them all through the single MCP
+endpoint — no changes to `server.py` ever needed.
+
+A minimal Python provider looks like this:
+
+```yaml
+code: |
+  import datetime
+  from typing import Any
+
+  async def ping(context: dict[str, Any], message: str = "hello") -> dict[str, Any]:
+      return {
+          "ok": True,
+          "echo": message,
+          "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+      }
+
+tools:
+  - name: ping
+    function: ping
+    description: Echo a message back with a server-side UTC timestamp.
+    input_schema:
+      type: object
+      properties:
+        message:
+          type: string
+          default: "hello"
+          description: The text to echo back.
+      required: []
+```
+
+An npx-based provider is even shorter — just point at the package:
+
+```yaml
+npx:
+  command: npx @playwright/mcp@latest --headless --isolated
+
+tools:
+  - name: browser_navigate
+    description: Navigate to a URL in a browser.
+    input_schema:
+      type: object
+      properties:
+        url:
+          type: string
+      required: [url]
+```
+
+## Secret Injection
+
+Secrets are declared in the provider YAML and injected from the environment at
+call time.  The key design property is that secret values are **never part of
+the MCP tool schema** — the LLM never sees them:
+
+```yaml
+tools:
+  - name: get_weather
+    function: get_weather
+    ...
+    secrets:
+      env:
+        api_key: WEATHER_API_KEY   # handler arg → env var name
+```
+
+The server reads `WEATHER_API_KEY` from `.env` (loaded via Docker Compose
+`env_file`) and passes it to the handler as the `api_key` argument.  The LLM's
+tool schema only shows the public parameters.
+
+## The Web UI
+
+A FastAPI frontend on port 8889 handles the full provider lifecycle.
+
+**Tools tab** — lists all loaded providers in a left panel.  Click any provider
+to open a form editor with its documentation, code, and per-tool fields (name,
+description, parameters).  Add or remove tools with the **+ Add Tool** / **✕**
+buttons, save to disk, and restart the MCP server in place — no shell access
+needed.
+
+**+ New Provider wizard** — choose between a Python code provider (write
+`async def` functions) and an npx package provider (enter an npx command;
+the UI auto-introspects the MCP server and populates tool definitions).  The
+wizard's final step lists all required secrets and writes them to `.env`
+directly.
+
+**🔑 Secrets panel** — reads all `secrets.env` entries from the selected
+provider, shows which variables are already set in `.env`, and lets you fill
+in or update missing values interactively.
+
+**🛠 Run Command** — runs any shell command inside the server environment and
+streams output live.  Particularly useful for npx-based providers: after adding
+a Playwright provider, install the Chrome binary with
+`npx playwright install chrome` right from the browser panel.
+
+## Connecting a Client
+
+The MCP endpoint is `http://localhost:8888/mcp`.  Most major clients support
+the HTTP transport natively:
+
+```bash
+# Claude Code
+claude mcp add --transport http mcpproxy http://localhost:8888/mcp
+```
+
+For Claude Desktop, Cursor, Cline, Continue, OpenCode, and Windsurf, add a
+JSON server entry pointing at the same URL.  For Ollama (which does not speak
+MCP natively), the included `tests/ollama_agent.py` bridges MCP → Ollama
+tool-calling automatically:
+
+```bash
+python3 tests/ollama_agent.py "List the tools you have available"
+```
+
+## Docker
+
+A pre-built image is published to the GitHub Container Registry on every push
+to `main`:
+
+```bash
+docker pull ghcr.io/billjr99/mcpproxy:latest
+docker run -d --rm \
+  -p 8888:8888 -p 8889:8889 \
+  --env-file .env \
+  -v "$(pwd)/tools":/app/tools \
+  --name mcpproxy \
+  ghcr.io/billjr99/mcpproxy:latest
+```
+
+The `tools/` directory is gitignored and never baked into the image — it is
+always mounted at runtime so your provider files stay outside the container.
+For a persistent home directory setup that also lets the web UI's Secrets
+panel read and write `.env`, bind-mount `~/.mcpproxy/.env` into the container
+and pass `-e MCP_ENV_FILE=/app/.env`.
+
+A `docker-compose.override.yml` is provided for local development with
+bind mounts; the base `docker-compose.yml` uses named volumes for
+production/CI.
+
+## Getting Started
+
+The fastest path is `run_local.sh`:
+
+```bash
+git clone https://github.com/BillJr99/mcpproxy
+cd mcpproxy
+./run_local.sh
+```
+
+The script generates `.env.example` from any existing tool YAMLs, prompts for
+missing secret values, creates a virtualenv, installs dependencies, and starts
+both the MCP server and the web UI.  Then open `http://localhost:8889`, click
+**+ New Provider**, and add your first tool.
+
+The unit test suite covers `server.py` helpers and all `frontend/app.py`
+endpoints and runs on every push via GitHub Actions:
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+pytest tests/ -v
+```
+
+Source code and further documentation are at
+[https://github.com/BillJr99/mcpproxy](https://github.com/BillJr99/mcpproxy).

--- a/_software/mcpproxy.md
+++ b/_software/mcpproxy.md
@@ -1,0 +1,102 @@
+---
+title: "mcpproxy"
+excerpt: "A config-driven MCP host that exposes a single HTTP MCP endpoint backed by YAML-defined tool providers, with a built-in web UI for editing providers, managing secrets, and streaming live command output."
+collection: software
+comments: true
+tags:
+  - ai
+  - mcp
+  - agentic
+  - technical
+  - software
+---
+
+> **Note:** `mcpproxy` is experimental software provided as-is, with no guarantees of security, stability, or fitness for any particular purpose.  It has not undergone a security audit.  Do not expose it to untrusted networks or use it to handle sensitive data in production.
+
+`mcpproxy` is a Dockerized, config-driven MCP host that presents a single `http://localhost:8888/mcp` endpoint to any MCP-capable AI client.  Every tool provider is a single YAML file: the YAML embeds the Python `async def` handler functions directly, declares the tool names, descriptions, and JSON Schema input schemas, and lists the environment variables the server should inject as secrets at call time.  Alternatively, a provider can delegate entirely to an existing MCP npm package via an `npx:` block, with no Python code required.  `server.py` loads all YAML files at startup, executes each `code` block or spawns the declared `npx` process, and registers every declared tool automatically — adding a new tool requires only a new YAML file, with no changes to the server.
+
+A FastAPI frontend (port 8889) provides a browser-based interface for the full provider lifecycle.  The Tools tab lists all loaded providers in a left panel; clicking a provider opens a form editor for its documentation, code, and per-tool fields, with buttons to add or remove tools, save the file, and restart the MCP server in place.  A **+ New Provider** wizard supports both Python code and npx package types; the wizard's final step lists all required secrets and writes them to `.env` without leaving the browser.  A **🔑 Secrets** panel reads declared `secrets.env` entries from the selected provider, shows which variables are already set, and lets you fill in or update values interactively.  A **🛠 Run Command** panel runs any shell command inside the server environment and streams output live — particularly useful for npx providers that need one-time setup, such as `npx playwright install chrome`.
+
+Secrets declared in a provider's `secrets.env` block are injected from the environment at call time; their values are never part of the MCP tool schema and are never visible to the LLM.  Docker Compose reads `.env` via `env_file`; the file is never baked into the image.  The `tools/` directory is similarly gitignored and must be mounted at runtime.
+
+A pre-built image is published to the GitHub Container Registry on every push to `main`:
+
+```bash
+docker pull ghcr.io/billjr99/mcpproxy:latest
+docker run -d --rm \
+  -p 8888:8888 -p 8889:8889 \
+  --env-file .env \
+  -v "$(pwd)/tools":/app/tools \
+  --name mcpproxy \
+  ghcr.io/billjr99/mcpproxy:latest
+```
+
+The package is hosted on GitHub at:
+
+[mcpproxy](https://github.com/BillJr99/mcpproxy)
+
+## Quick Start
+
+```bash
+git clone https://github.com/BillJr99/mcpproxy
+cd mcpproxy
+./run_local.sh
+```
+
+`run_local.sh` generates `.env.example` from any existing tool YAMLs, prompts for missing secret values, creates a virtualenv, installs dependencies, and starts the server.  The MCP endpoint is at `http://localhost:8888/mcp` and the web UI at `http://localhost:8889`.
+
+## Connecting AI Clients
+
+`mcpproxy` works with any client that speaks the MCP HTTP transport.  A few examples:
+
+| Client | Configuration |
+|---|---|
+| **Claude Code** | `claude mcp add --transport http mcpproxy http://localhost:8888/mcp` |
+| **Claude Desktop** | Add `{"url": "http://localhost:8888/mcp", "transport": "http"}` to `claude_desktop_config.json` |
+| **Cursor** | Add a server entry in Settings → Features → MCP |
+| **Cline** | MCP Servers tab → Add MCP Server, transport HTTP/SSE |
+| **Continue** | Add an entry to `.continue/config.json` |
+| **OpenCode** | Add to `opencode.json` under `mcp.servers` |
+| **Windsurf** | Settings → Cascade → MCP |
+| **Ollama** | Use the included `tests/ollama_agent.py` bridge script |
+
+## Provider YAML Reference
+
+Each YAML file under `tools/` follows this schema:
+
+```yaml
+documentation: |           # optional; shown in the web UI
+  Describe this provider.
+
+code: |                    # Python source executed once at startup
+  async def my_tool(context, arg1, arg2):
+      return {"ok": True, "result": arg1}
+
+# -- OR -- (mutually exclusive with code)
+npx:
+  command: npx @playwright/mcp@latest --headless --isolated
+
+tools:
+  - name: my_tool
+    function: my_tool      # async function name from code block
+    description: "..."
+    input_schema:
+      type: object
+      properties:
+        arg1: {type: string}
+      required: [arg1]
+    secrets:
+      env:
+        arg2: MY_SERVICE_API_KEY
+```
+
+Secrets are injected from the environment; they are never part of the tool schema.
+
+## Test Suite
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+pytest tests/ -v
+```
+
+Unit tests cover `server.py` helpers and all `frontend/app.py` API endpoints.  Additional shell scripts (`tests/mcp_interactive.sh`, `tests/test_with_ollama.sh`) and a Python agentic loop (`tests/ollama_agent.py`) support end-to-end validation against a running server.


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for `mcpproxy`, a config-driven MCP host with a built-in web UI. Two new documentation files are added: a detailed blog post and a software project page.

## Changes

- **`_posts/2026-05-25-mcpproxy.md`** — A detailed blog post covering:
  - Overview of mcpproxy's design philosophy and key features
  - How the config-driven YAML provider system works
  - Examples of minimal Python and npx-based providers
  - Secret injection mechanism and security model
  - Web UI capabilities (Tools tab, New Provider wizard, Secrets panel, Run Command)
  - Client connection instructions for major AI platforms
  - Docker deployment and setup instructions
  - Getting started guide with `run_local.sh`
  - Testing instructions

- **`_software/mcpproxy.md`** — A concise software project page with:
  - Executive summary of mcpproxy's functionality
  - Quick start instructions
  - Compatibility table for major AI clients (Claude Code, Claude Desktop, Cursor, Cline, Continue, OpenCode, Windsurf, Ollama)
  - Provider YAML schema reference
  - Test suite instructions
  - Link to GitHub repository

## Notable Details

- Both documents emphasize the experimental nature and security considerations of the software
- Documentation includes practical examples (YAML provider definitions, Docker commands, client configuration)
- The software page provides a quick reference table for client integration, while the blog post offers deeper narrative explanation
- Both reference the same GitHub repository and highlight the key innovation: zero-code tool addition via YAML configuration

https://claude.ai/code/session_011W7GBfPac8DrEdRtJsXP6R